### PR TITLE
Create commit statuses instead of posting comment

### DIFF
--- a/internal/agreement.go
+++ b/internal/agreement.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -12,7 +13,7 @@ type AgreementOptions struct {
 // AgreementReached determines whether members have reached an agreement
 // If the number of members who answered true is greater than the
 // threshold the function returns true.
-func AgreementReached(members []string, votes map[string]bool, opts *AgreementOptions) bool {
+func AgreementReached(members []string, votes map[string]bool, opts *AgreementOptions) (bool, string) {
 	if opts == nil {
 		opts = &AgreementOptions{Threshold: 1, NeedsConsensus: true}
 	}
@@ -27,8 +28,12 @@ func AgreementReached(members []string, votes map[string]bool, opts *AgreementOp
 			numFor++
 		} else if (*opts).NeedsConsensus {
 			// Return out early if we need a consensus
-			return false
+			return false, "consensus needed"
 		}
 	}
-	return numFor >= (*opts).Threshold
+	if numFor >= (*opts).Threshold {
+		return true, ""
+	} else {
+		return false, fmt.Sprintf("%d more approval(s) needed", (*opts).Threshold-numFor)
+	}
 }

--- a/internal/agreement_test.go
+++ b/internal/agreement_test.go
@@ -36,7 +36,7 @@ func TestAgreementReached(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		actual := AgreementReached(testcase.members, testcase.votes, testcase.opts)
+		actual, _ := AgreementReached(testcase.members, testcase.votes, testcase.opts)
 		if actual != testcase.expected {
 			t.Errorf(
 				"Expected: %v, Got %v\nmembers: %v\nvotes: %v\nopts: %v",

--- a/internal/webhook.go
+++ b/internal/webhook.go
@@ -302,9 +302,10 @@ func mergePullRequest(client *github.Client, owner, repo, sha string, prNumber i
 		return
 	}
 
+	reached, reason := AgreementReached(config.Whitelist, votes, &opts)
 	// Exit early on non-agreements
-	if !AgreementReached(config.Whitelist, votes, &opts) {
-		doStatus("setting pending status", "pending", "Waiting to merge automatically...")
+	if !reached {
+		doStatus("setting pending status", "pending", fmt.Sprintf("Automatic merge is pending, %s", reason))
 		log.Infof("Agreement not reached! Staying put on %s", githubURL)
 		return
 	}

--- a/internal/webhook.go
+++ b/internal/webhook.go
@@ -277,13 +277,35 @@ func mergePullRequest(client *github.Client, owner, repo, sha string, prNumber i
 		mergeMethod = config.MergeMethod
 	}
 
-	// Exit early on non-agreements
-	if !AgreementReached(config.Whitelist, votes, &opts) {
-		log.Infof("Agreement not reached! Staying put on %s", githubURL)
-		return
+	doStatus := func(step, state, description string) {
+		statusContext := "unir"
+		// Create a commit status on the SHA that represents the merge status
+		_, _, err = client.Repositories.CreateStatus(
+			ctx,
+			owner,
+			repo,
+			sha,
+			&github.RepoStatus{
+				State:       &state,
+				Description: &description,
+				Context:     &statusContext,
+			},
+		)
+
+		if err != nil {
+			log.Errorf("Creating commit status failed for %s on step %s: %v", githubURL, step, err)
+		}
 	}
 
 	if editingConfig(ctx, client, owner, repo, prNumber) {
+		doStatus("config editing", "failure", "Unable to merge automatically, editing unir config")
+		return
+	}
+
+	// Exit early on non-agreements
+	if !AgreementReached(config.Whitelist, votes, &opts) {
+		doStatus("setting pending status", "pending", "Waiting to merge automatically...")
+		log.Infof("Agreement not reached! Staying put on %s", githubURL)
 		return
 	}
 
@@ -300,19 +322,9 @@ func mergePullRequest(client *github.Client, owner, repo, sha string, prNumber i
 	// We don't reach our success criteria
 	if resp.StatusCode != 200 {
 		log.Errorf("Merge failed for %s: %s, %v", githubURL, result.GetMessage(), err)
-		errorMessage := fmt.Sprintf("Unable to merge! %s", result.GetMessage())
-		_, _, err := client.Issues.CreateComment(
-			ctx,
-			owner,
-			repo,
-			prNumber,
-			&github.IssueComment{Body: &errorMessage},
-		)
-		if err != nil {
-			log.Errorf("Error posting comment in %s: %v", githubURL, err)
-		}
+		doStatus("merge failure", "failure", "Failed to merge automatically")
 		return
 	}
-
+	doStatus("successful merge", "success", "Merged automatically with unir")
 	log.Infof("Merge successful for %s", githubURL)
 }


### PR DESCRIPTION
Comments are too hard to do correctly without making multiple API calls
so I've opted to do commit statuses instead for every major part. This
should also alert users when unir is unable to merge or pending to
merge.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>